### PR TITLE
Misc updates

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-http-types",
+        "repositoryURL": "https://github.com/apple/swift-http-types.git",
+        "state": {
+          "branch": null,
+          "revision": "1ddbea1ee34354a6a2532c60f98501c35ae8edfa",
+          "version": "1.2.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -21,13 +21,17 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-http-types.git", .upToNextMajor(from: "1.1.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "WSPublisher",
-            dependencies: [],
+            dependencies: [
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+                .product(name: "HTTPTypesFoundation", package: "swift-http-types"),
+            ],
             resources: [.copy("../PrivacyInfo.xcprivacy")]
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fedonv%2FWSPublisher%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/edonv/WSPublisher)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fedonv%2FWSPublisher%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/edonv/WSPublisher)
 
-`WSPublisher` is a library for easy `Combine`-based communication via [WebSocket](https://en.wikipedia.org/wiki/WebSocket). It also has async/await overloads. It's written in pure Swift, has no third-party dependencies, and is built entirely on top of Swift's native [URLSessionWebSocketTask](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask).
+`WSPublisher` is a client library for easy `Combine`-based communication via [WebSocket](https://en.wikipedia.org/wiki/WebSocket). It also has async/await overloads. It's written in pure Swift, has no third-party dependencies, and is built entirely on top of Swift's native [URLSessionWebSocketTask](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask).
 
 While this library can be used for any WebSocket communication, it was built as a modular piece of the puzzle that is my [OBSwiftSocket library](https://github.com/edonv/OBSwiftSocket).

--- a/Sources/WSPublisher/Extensions/URLSessionWebSocketTaskCloseCode+StringConvertible.swift
+++ b/Sources/WSPublisher/Extensions/URLSessionWebSocketTaskCloseCode+StringConvertible.swift
@@ -1,0 +1,84 @@
+//
+//  URLSessionWebSocketTaskCloseCode+StringConvertible.swift
+//
+//
+//  Created by Edon Valdman on 6/21/24.
+//
+
+import Foundation
+
+extension URLSessionWebSocketTask.CloseCode: CustomStringConvertible, CustomDebugStringConvertible {
+    public var description: String {
+        return "\(_caseName) (\(rawValue))"
+    }
+    
+    private var _caseName: String {
+        switch self {
+        case .invalid:
+            return "invalid"
+        case .normalClosure:
+            return "normalClosure"
+        case .goingAway:
+            return "goingAway"
+        case .protocolError:
+            return "protocolError"
+        case .unsupportedData:
+            return "unsupportedData"
+        case .noStatusReceived:
+            return "noStatusReceived"
+        case .abnormalClosure:
+            return "abnormalClosure"
+        case .invalidFramePayloadData:
+            return "invalidFramePayloadData"
+        case .policyViolation:
+            return "policyViolation"
+        case .messageTooBig:
+            return "messageTooBig"
+        case .mandatoryExtensionMissing:
+            return "mandatoryExtensionMissing"
+        case .internalServerError:
+            return "internalServerError"
+        case .tlsHandshakeFailure:
+            return "tlsHandshakeFailure"
+        @unknown default:
+            return "Unknown close code"
+        }
+    }
+    
+    public var debugDescription: String {
+        return "\(_caseName)/\(rawValue) (\(_detail))"
+    }
+    
+    private var _detail: String {
+        switch self {
+        case .abnormalClosure:
+            return "The connection closed without a close control frame."
+        case .goingAway:
+            return "An endpoint went away."
+        case .internalServerError:
+            return "The server terminated the connection because it encountered an unexpected condition."
+        case .invalid:
+            return "The connection is still open."
+        case .invalidFramePayloadData:
+            return "The server terminated the connection because it received data inconsistent with the message's type."
+        case .mandatoryExtensionMissing:
+            return "The client terminated the connection because the server didn't negotiate a required extension."
+        case .messageTooBig:
+            return "An endpoint terminated the connection because it received a message too big for it to process."
+        case .noStatusReceived:
+            return "An endpoint expected a status code and didn't receive one."
+        case .normalClosure:
+            return "Normal connection closure."
+        case .policyViolation:
+            return "An endpoint terminated the connection because it received a message that violates its policy."
+        case .protocolError:
+            return "An endpoint terminated the connection due to a protocol error."
+        case .tlsHandshakeFailure:
+            return "The connection failed to perform a TLS handshake."
+        case .unsupportedData:
+            return "An endpoint terminated the connection after receiving a type of data it can't accept."
+        @unknown default:
+            return "Unknown close code."
+        }
+    }
+}

--- a/Sources/WSPublisher/Extensions/URLSessionWebSocketTaskMessage+Hashable.swift
+++ b/Sources/WSPublisher/Extensions/URLSessionWebSocketTaskMessage+Hashable.swift
@@ -1,0 +1,30 @@
+//
+//  URLSessionWebSocketTaskMessage+Hashable.swift
+//
+//
+//  Created by Edon Valdman on 6/21/24.
+//
+
+import Foundation
+
+extension URLSessionWebSocketTask.Message: Hashable {
+    private var comparisonValue: AnyHashable {
+        switch self {
+        case .data(let d):
+            return d as AnyHashable
+        case .string(let s):
+            return s as AnyHashable
+            
+        @unknown default:
+            return self as AnyHashable
+        }
+    }
+    
+    public static func == (lhs: URLSessionWebSocketTask.Message, rhs: URLSessionWebSocketTask.Message) -> Bool {
+        lhs.comparisonValue == rhs.comparisonValue
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.comparisonValue)
+    }
+}

--- a/Sources/WSPublisher/Extensions/WSPublisher+SwiftUI.swift
+++ b/Sources/WSPublisher/Extensions/WSPublisher+SwiftUI.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import Combine
+import HTTPTypes
 
 extension View {
     /// Adds an action to perform when this view detects an ``WebSocketPublisher/Event`` emitted by the given ``WebSocketPublisher``.

--- a/Sources/WSPublisher/Extensions/WSPublisher+SwiftUI.swift
+++ b/Sources/WSPublisher/Extensions/WSPublisher+SwiftUI.swift
@@ -23,14 +23,14 @@ extension View {
     
     public func onWebSocketConnect(
         _ manager: WebSocketPublisher,
-        perform action: @escaping (_ protocol: String?) -> Void
+        perform action: @escaping (_ protocol: String?, _ headers: HTTPFields) -> Void
     ) -> some View {
         self.onReceive(
             manager.publisher
                 // Explicitly noted as String?? so it doesn't fully-unwrap the parameter
-                .compactMap { event -> String?? in
-                    guard case .connected(let p) = event else { return nil }
-                    return p
+                .compactMap { event -> (String?, HTTPFields)? in
+                    guard case .connected(let p, let headers) = event else { return nil }
+                    return (p, headers)
                 },
             perform: action
         )

--- a/Sources/WSPublisher/Extensions/WSPublisher+SwiftUI.swift
+++ b/Sources/WSPublisher/Extensions/WSPublisher+SwiftUI.swift
@@ -44,13 +44,13 @@ extension View {
     /// - Returns: A view that triggers `action` when `manager` emits an event.
     public func onWebSocketDisconnect(
         _ manager: WebSocketPublisher,
-        perform action: @escaping (_ closeCode: URLSessionWebSocketTask.CloseCode, _ reason: String?) -> Void
+        perform action: @escaping (_ disconnect: WebSocketPublisher.Event.Disconnect) -> Void
     ) -> some View {
         self.onReceive(
             manager.publisher
                 .compactMap { event in
-                    guard case .disconnected(let closeCode, let reason) = event else { return nil }
-                    return (closeCode, reason)
+                    guard case .disconnected(let disconnect) = event else { return nil }
+                    return disconnect
                 },
             perform: action
         )

--- a/Sources/WSPublisher/Extensions/WSPublisher+SwiftUI.swift
+++ b/Sources/WSPublisher/Extensions/WSPublisher+SwiftUI.swift
@@ -24,14 +24,13 @@ extension View {
     
     public func onWebSocketConnect(
         _ manager: WebSocketPublisher,
-        perform action: @escaping (_ protocol: String?, _ headers: HTTPFields) -> Void
+        perform action: @escaping (_ connect: WebSocketPublisher.Event.Connect) -> Void
     ) -> some View {
         self.onReceive(
             manager.publisher
-                // Explicitly noted as String?? so it doesn't fully-unwrap the parameter
-                .compactMap { event -> (String?, HTTPFields)? in
-                    guard case .connected(let p, let headers) = event else { return nil }
-                    return (p, headers)
+                .compactMap { event in
+                    guard case .connected(let connect) = event else { return nil }
+                    return connect
                 },
             perform: action
         )

--- a/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
+++ b/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
@@ -15,8 +15,7 @@ extension WebSocketPublisher: URLSessionWebSocketDelegate {
     /// This function is called automatically by the delegate system when the WebSocket connection
     /// opens successfully.
     public func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
-        let headers = webSocketTask.httpResponse?.headerFields ?? [:]
-        _subject.send(.connected(`protocol`, upgradeHeaders: headers))
+        _subject.send(.connected(`protocol`, response: webSocketTask.httpResponse ?? .init(status: .switchingProtocols)))
         startListening()
     }
     

--- a/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
+++ b/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
@@ -20,7 +20,7 @@ extension WebSocketPublisher: URLSessionWebSocketDelegate {
     /// This function is called automatically by the delegate system when the WebSocket connection
     /// is closed.
     public func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
-        clearTaskData()
+        defer { clearTaskData() }
         
         let reasonStr = reason != nil ? String(data: reason!, encoding: .utf8) : nil
         let event = Event.disconnected(closeCode, reasonStr)

--- a/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
+++ b/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Combine
 
+import HTTPTypes
 import HTTPTypesFoundation
 
 extension WebSocketPublisher: URLSessionWebSocketDelegate {

--- a/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
+++ b/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
@@ -8,11 +8,14 @@
 import Foundation
 import Combine
 
+import HTTPTypesFoundation
+
 extension WebSocketPublisher: URLSessionWebSocketDelegate {
     /// This function is called automatically by the delegate system when the WebSocket connection
     /// opens successfully.
     public func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
-        let event = Event.connected(`protocol`)
+        let headers = webSocketTask.httpResponse?.headerFields ?? [:]
+        let event = Event.connected(`protocol`, upgradeHeaders: headers)
         _subject.send(event)
         startListening()
     }

--- a/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
+++ b/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
@@ -23,7 +23,6 @@ extension WebSocketPublisher: URLSessionWebSocketDelegate {
         defer { clearTaskData() }
         
         let reasonStr = reason != nil ? String(data: reason!, encoding: .utf8) : nil
-        let event = Event.disconnected(closeCode, reasonStr)
-        _subject.send(event)
+        _subject.send(.disconnected(closeCode, reasonStr))
     }
 }

--- a/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
+++ b/Sources/WSPublisher/Extensions/WebSocketPublisher+URLSessionDelegate.swift
@@ -15,8 +15,7 @@ extension WebSocketPublisher: URLSessionWebSocketDelegate {
     /// opens successfully.
     public func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
         let headers = webSocketTask.httpResponse?.headerFields ?? [:]
-        let event = Event.connected(`protocol`, upgradeHeaders: headers)
-        _subject.send(event)
+        _subject.send(.connected(`protocol`, upgradeHeaders: headers))
         startListening()
     }
     

--- a/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
+++ b/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
@@ -17,7 +17,7 @@ extension WebSocketPublisher {
     public typealias WSEvent = Event
     
     /// Events that are published via ``WebSocketPublisher/publisher``.
-    public enum Event {
+    public enum Event: Hashable, Sendable {
         /// Occurs when ``WebSocketPublisher/publisher`` is initially created.
         case publisherCreated
         
@@ -43,7 +43,7 @@ extension WebSocketPublisher {
 extension WebSocketPublisher.Event {
     // MARK: - .connected
     
-    public struct Connect: Sendable {
+    public struct Connect: Sendable, Hashable {
         public let `protocol`: String?
         public let response: HTTPResponse
         
@@ -63,7 +63,7 @@ extension WebSocketPublisher.Event {
     
     // MARK: - .disconnected
     
-    public enum Disconnect: Sendable {
+    public enum Disconnect: Sendable, Hashable {
         /// The connection closes safely with a close code, and optionally with a descriptive reason.
         case closeCode(_ closeCode: URLSessionWebSocketTask.CloseCode, _ reason: String?)
         
@@ -78,7 +78,7 @@ extension WebSocketPublisher.Event {
         case urlError(URLError)
         
         /// Some other type of `Error` occurs that isn't a `URLError`.
-        case unknownError(Error)
+        case unknownError(NSError)
     }
     
     /// Occurs when the connection is closed.
@@ -100,7 +100,7 @@ extension WebSocketPublisher.Event {
     
     /// Occurs when the connection is closed.
     public static func disconnected(_ error: Error) -> WebSocketPublisher.Event {
-        .disconnected(.unknownError(error))
+        .disconnected(.unknownError(error as NSError))
     }
 }
 

--- a/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
+++ b/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
@@ -103,7 +103,8 @@ extension WebSocketPublisher.Event: CustomStringConvertible {
             let detail: String
             switch disconnect {
             case .closeCode(let code, let reason):
-                detail = "code: \(code), reason: \(reason ?? "nil")"
+                let reasonStr = reason.map { "\"\($0)\""} ?? "nil"
+                detail = "code: \(code), reason: \(reasonStr)"
             case .urlError(let urlError):
                 detail = "error: \(urlError)"
             case .unknownError(let error):

--- a/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
+++ b/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
@@ -25,7 +25,7 @@ extension WebSocketPublisher {
         case connected(_ protocol: String?, upgradeHeaders: HTTPFields)
         
         /// Occurs when the connection is closed.
-        case disconnected(_ closeCode: URLSessionWebSocketTask.CloseCode, _ reason: String?)
+        case disconnected(Disconnect)
         
         /// Occurs when ``WebSocketPublisher/webSocketTask`` receives a `Data` message.
         case data(Data)
@@ -37,5 +37,47 @@ extension WebSocketPublisher {
         /// [`URLSessionWebSocketTask.Message`](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask/message)
         /// being made with the possibility of new cases.
         case generic(URLSessionWebSocketTask.Message)
+        
+        /// Occurs when the connection is closed.
+        public static func disconnected(_ closeCode: URLSessionWebSocketTask.CloseCode, _ reason: String?) -> Event {
+            .disconnected(.closeCode(closeCode, reason))
+        }
+        
+        /// The connection closes with a [`URLError`](https://developer.apple.com/documentation/foundation/urlerror), instead of with a close code.
+        ///
+        /// # Examples
+        /// Common scenarios include:
+        /// - Attemping to establish a connection with a URL that doesn't support a WebSocket connection.
+        /// - Attemping to establish a connection that fails the WebSocket handshake.
+        /// - ~~A connected WebSocket server closes without sending a close code.~~
+        ///     - This scenario is being internally mapped to a ``disconnected(_:_:)`` type.
+        public static func disconnected(_ urlError: URLError) -> Event {
+            .disconnected(.urlError(urlError))
+        }
+        
+        /// Occurs when the connection is closed.
+        public static func disconnected(_ error: Error) -> Event {
+            .disconnected(.unknownError(error))
+        }
+    }
+}
+
+extension WebSocketPublisher.Event {
+    public enum Disconnect: Sendable {
+        /// The connection closes safely with a close code, and optionally with a descriptive reason.
+        case closeCode(_ closeCode: URLSessionWebSocketTask.CloseCode, _ reason: String?)
+        
+        /// The connection closes with an error, instead of with a close code.
+        ///
+        /// # Examples
+        /// Common scenarios include:
+        /// - Attemping to establish a connection with a URL that doesn't support a WebSocket connection.
+        /// - Attemping to establish a connection that fails the WebSocket handshake.
+        /// - ~~A connected WebSocket server closes without sending a close code.~~
+        ///     - This scenario is being internally mapped to a ``disconnected(_:_:)`` type.
+        case urlError(URLError)
+        
+        /// Some other type of `Error` occurs that isn't a `URLError`.
+        case unknownError(Error)
     }
 }

--- a/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
+++ b/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
@@ -37,32 +37,12 @@ extension WebSocketPublisher {
         /// [`URLSessionWebSocketTask.Message`](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask/message)
         /// being made with the possibility of new cases.
         case generic(URLSessionWebSocketTask.Message)
-        
-        /// Occurs when the connection is closed.
-        public static func disconnected(_ closeCode: URLSessionWebSocketTask.CloseCode, _ reason: String?) -> Event {
-            .disconnected(.closeCode(closeCode, reason))
-        }
-        
-        /// The connection closes with a [`URLError`](https://developer.apple.com/documentation/foundation/urlerror), instead of with a close code.
-        ///
-        /// # Examples
-        /// Common scenarios include:
-        /// - Attemping to establish a connection with a URL that doesn't support a WebSocket connection.
-        /// - Attemping to establish a connection that fails the WebSocket handshake.
-        /// - ~~A connected WebSocket server closes without sending a close code.~~
-        ///     - This scenario is being internally mapped to a ``disconnected(_:_:)`` type.
-        public static func disconnected(_ urlError: URLError) -> Event {
-            .disconnected(.urlError(urlError))
-        }
-        
-        /// Occurs when the connection is closed.
-        public static func disconnected(_ error: Error) -> Event {
-            .disconnected(.unknownError(error))
-        }
     }
 }
 
 extension WebSocketPublisher.Event {
+    // MARK: - .disconnected
+    
     public enum Disconnect: Sendable {
         /// The connection closes safely with a close code, and optionally with a descriptive reason.
         case closeCode(_ closeCode: URLSessionWebSocketTask.CloseCode, _ reason: String?)
@@ -79,6 +59,28 @@ extension WebSocketPublisher.Event {
         
         /// Some other type of `Error` occurs that isn't a `URLError`.
         case unknownError(Error)
+    }
+    
+    /// Occurs when the connection is closed.
+    public static func disconnected(_ closeCode: URLSessionWebSocketTask.CloseCode, _ reason: String?) -> WebSocketPublisher.Event {
+        .disconnected(.closeCode(closeCode, reason))
+    }
+    
+    /// The connection closes with a [`URLError`](https://developer.apple.com/documentation/foundation/urlerror), instead of with a close code.
+    ///
+    /// # Examples
+    /// Common scenarios include:
+    /// - Attemping to establish a connection with a URL that doesn't support a WebSocket connection.
+    /// - Attemping to establish a connection that fails the WebSocket handshake.
+    /// - ~~A connected WebSocket server closes without sending a close code.~~
+    ///     - This scenario is being internally mapped to a ``disconnected(_:_:)`` type.
+    public static func disconnected(_ urlError: URLError) -> WebSocketPublisher.Event {
+        .disconnected(.urlError(urlError))
+    }
+    
+    /// Occurs when the connection is closed.
+    public static func disconnected(_ error: Error) -> WebSocketPublisher.Event {
+        .disconnected(.unknownError(error))
     }
 }
 

--- a/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
+++ b/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import HTTPTypes
+
 /// A non-namespaced shorthand for ``WebSocketPublisher/Event``.
 public typealias WSEvent = WebSocketPublisher.Event
 
@@ -20,7 +22,7 @@ extension WebSocketPublisher {
         case publisherCreated
         
         /// Occurs when the connection is opened successfully.
-        case connected(_ protocol: String?)
+        case connected(_ protocol: String?, upgradeHeaders: HTTPFields)
         
         /// Occurs when the connection is closed.
         case disconnected(_ closeCode: URLSessionWebSocketTask.CloseCode, _ reason: String?)

--- a/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
+++ b/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
@@ -24,7 +24,7 @@ extension WebSocketPublisher {
         /// Occurs when the connection is opened successfully.
         case connected(_ protocol: String?, upgradeHeaders: HTTPFields)
         
-        /// Occurs when the connection is closed.
+        /// Occurs when the connection is closed, or it fails to connect.
         case disconnected(Disconnect)
         
         /// Occurs when ``WebSocketPublisher/webSocketTask`` receives a `Data` message.

--- a/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
+++ b/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
@@ -81,3 +81,42 @@ extension WebSocketPublisher.Event {
         case unknownError(Error)
     }
 }
+
+extension WebSocketPublisher.Event: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .publisherCreated:
+            return "publisherCreated"
+        case .connected(let p, let upgradeHeaders):
+            var strs = [String]()
+            if let p {
+                strs.append("protocol: \(p)")
+            }
+            if !upgradeHeaders.isEmpty {
+                strs.append("headers: [\(upgradeHeaders.map(\.description).joined(separator: ", "))]")
+            }
+            let suffix = strs.isEmpty ? "" : "(" + strs
+                .joined(separator: ", ") + ")"
+            return "connected" + suffix
+        
+        case .disconnected(let disconnect):
+            let detail: String
+            switch disconnect {
+            case .closeCode(let code, let reason):
+                detail = "code: \(code), reason: \(reason ?? "nil")"
+            case .urlError(let urlError):
+                detail = "error: \(urlError)"
+            case .unknownError(let error):
+                detail = "error: \(error)"
+            }
+            
+            return "disconnected(\(detail))"
+        case .data(let data):
+            return "data(\(data))"
+        case .string(let string):
+            return "string(\"\(string)\")"
+        case .generic(let message):
+            return "generic(\(message))"
+        }
+    }
+}

--- a/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
+++ b/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
@@ -34,7 +34,7 @@ extension WebSocketPublisher {
         case string(String)
         
         /// This is used as a fallback, due to
-        /// [URLSessionWebSocketTask.Message](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask/message)
+        /// [`URLSessionWebSocketTask.Message`](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask/message)
         /// being made with the possibility of new cases.
         case generic(URLSessionWebSocketTask.Message)
     }

--- a/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
+++ b/Sources/WSPublisher/Types/WebSocketPublisher+Event.swift
@@ -22,7 +22,7 @@ extension WebSocketPublisher {
         case publisherCreated
         
         /// Occurs when the connection is opened successfully.
-        case connected(_ protocol: String?, upgradeHeaders: HTTPFields)
+        case connected(Connect)
         
         /// Occurs when the connection is closed, or it fails to connect.
         case disconnected(Disconnect)
@@ -41,6 +41,26 @@ extension WebSocketPublisher {
 }
 
 extension WebSocketPublisher.Event {
+    // MARK: - .connected
+    
+    public struct Connect: Sendable {
+        public let `protocol`: String?
+        public let response: HTTPResponse
+        
+        public var headers: HTTPFields {
+            response.headerFields
+        }
+        
+        internal init(_ protocol: String?, response: HTTPResponse) {
+            self.protocol = `protocol`
+            self.response = response
+        }
+    }
+    
+    public static func connected(_ protocol: String?, response: HTTPResponse) -> WebSocketPublisher.Event {
+        .connected(Connect(`protocol`, response: response))
+    }
+    
     // MARK: - .disconnected
     
     public enum Disconnect: Sendable {
@@ -89,13 +109,13 @@ extension WebSocketPublisher.Event: CustomStringConvertible {
         switch self {
         case .publisherCreated:
             return "publisherCreated"
-        case .connected(let p, let upgradeHeaders):
+        case .connected(let connect):
             var strs = [String]()
-            if let p {
-                strs.append("protocol: \(p)")
+            if let p = connect.protocol {
+                strs.append("protocol: \"\(p)\"")
             }
-            if !upgradeHeaders.isEmpty {
-                strs.append("headers: [\(upgradeHeaders.map(\.description).joined(separator: ", "))]")
+            if !connect.headers.isEmpty {
+                strs.append("headers: [\(connect.headers.map(\.description).joined(separator: ", "))]")
             }
             let suffix = strs.isEmpty ? "" : "(" + strs
                 .joined(separator: ", ") + ")"

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -11,7 +11,7 @@ import Combine
 import HTTPTypes
 import HTTPTypesFoundation
 
-/// Wraps around a subscribable [Publisher](https://developer.apple.com/documentation/combine/publisher)
+/// Wraps around a subscribable [`Publisher`](https://developer.apple.com/documentation/combine/publisher)
 /// for connection over WebSocket.
 public class WebSocketPublisher: NSObject {
     /// The `URLRequest` used for creating an `URLSession` to start a connection.
@@ -21,10 +21,10 @@ public class WebSocketPublisher: NSObject {
     /// containing the active connection, when there is one.
     public private(set) var webSocketTask: URLSessionWebSocketTask? = nil
     
-    /// Used for storing active `Combine` [Cancellable](https://developer.apple.com/documentation/combine/cancellable)s.
+    /// Used for storing active `Combine` [`Cancellable`](https://developer.apple.com/documentation/combine/cancellable)s.
     private var observers = Set<AnyCancellable>()
     
-    /// The [Subject](https://developer.apple.com/documentation/combine/subject) that publishes all received ``WebSocketPublisher/Event``s.
+    /// The [`Subject`](https://developer.apple.com/documentation/combine/subject) that publishes all received ``WebSocketPublisher/Event``s.
     internal let _subject = CurrentValueSubject<Event, Never>(.publisherCreated)
     
     /// Returns the internal [Publisher](https://developer.apple.com/documentation/combine/publisher) (really a

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -24,7 +24,7 @@ public class WebSocketPublisher: NSObject {
     /// Used for storing active `Combine` [Cancellable](https://developer.apple.com/documentation/combine/cancellable)s.
     private var observers = Set<AnyCancellable>()
     
-    /// The (Subject)[https://developer.apple.com/documentation/combine/subject] that publishes all received ``WebSocketPublisher/Event``s.
+    /// The [Subject](https://developer.apple.com/documentation/combine/subject) that publishes all received ``WebSocketPublisher/Event``s.
     internal let _subject = CurrentValueSubject<Event, Never>(.publisherCreated)
     
     /// Returns the internal [Publisher](https://developer.apple.com/documentation/combine/publisher) (really a

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -53,7 +53,9 @@ public class WebSocketPublisher: NSObject {
     }
     
     /// Creates and starts a WebSocket connection.
-    /// - Parameter request: The connection data to connect to.
+    /// - Parameters:
+    ///   - request: The connection data to connect to.
+    ///   - headers: Optional additional headers to include in the initial connection request.
     public func connect(with request: URLRequest, headers: HTTPFields? = nil) {
         var req = request.httpRequest!
         if let headers {
@@ -68,7 +70,9 @@ public class WebSocketPublisher: NSObject {
     }
     
     /// Creates and starts a WebSocket connection.
-    /// - Parameter url: The `URL` to connect to.
+    /// - Parameters:
+    ///   - url: The `URL` to connect to.
+    ///   - headers: Optional additional headers to include in the initial connection request.
     public func connect(with url: URL, headers: HTTPFields? = nil) {
         connect(with: URLRequest(url: url), headers: headers)
     }

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -180,8 +180,7 @@ public class WebSocketPublisher: NSObject {
                 switch result {
                 case .finished:
                     self?.startListening()
-                case .failure(let err):
-                    self?._subject.send(.disconnected(.abnormalClosure, err.localizedDescription))
+                case .failure:
                     self?.clearTaskData()
                 }
             }, receiveValue: { [weak self] message in

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -8,6 +8,9 @@
 import Foundation
 import Combine
 
+import HTTPTypes
+import HTTPTypesFoundation
+
 /// Wraps around a subscribable [Publisher](https://developer.apple.com/documentation/combine/publisher)
 /// for connection over WebSocket.
 public class WebSocketPublisher: NSObject {
@@ -47,9 +50,14 @@ public class WebSocketPublisher: NSObject {
     
     /// Creates and starts a WebSocket connection.
     /// - Parameter request: The connection data to connect to.
-    public func connect(with request: URLRequest) {
+    public func connect(with request: URLRequest, headers: HTTPFields? = nil) {
+        var req = request.httpRequest!
+        if let headers {
+            req.headerFields = headers
+        }
+        
         let session = URLSession(configuration: .default, delegate: self, delegateQueue: OperationQueue())
-        webSocketTask = session.webSocketTask(with: request)
+        webSocketTask = session.webSocketTask(with: URLRequest(httpRequest: req)!)
         
         webSocketTask?.resume()
         self.urlRequest = request
@@ -57,8 +65,8 @@ public class WebSocketPublisher: NSObject {
     
     /// Creates and starts a WebSocket connection.
     /// - Parameter url: The `URL` to connect to.
-    public func connect(with url: URL) {
-        connect(with: URLRequest(url: url))
+    public func connect(with url: URL, headers: HTTPFields? = nil) {
+        connect(with: URLRequest(url: url), headers: headers)
     }
     
     /// Disconnects from ``WebSocketPublisher/webSocketTask``, if there is an active connection.

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -176,14 +176,14 @@ public class WebSocketPublisher: NSObject {
         
         task.receiveOnce()
             .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { [weak self] result in
+            .sink { [weak self] result in
                 switch result {
                 case .finished:
                     self?.startListening()
                 case .failure:
                     break
                 }
-            }, receiveValue: { [weak self] message in
+            } receiveValue: { [weak self] message in
                 switch message {
                 case .data(let d):
                     self?._subject.send(.data(d))
@@ -192,7 +192,7 @@ public class WebSocketPublisher: NSObject {
                 @unknown default:
                     self?._subject.send(.generic(message))
                 }
-            })
+            }
             .store(in: &observers)
     }
 }

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -41,6 +41,13 @@ public class WebSocketPublisher: NSObject {
         }
     }
     
+    private let _operationQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "WebSocketPublisher.queue"
+        queue.qualityOfService = .userInitiated
+        return queue
+    }()
+    
     public override init() {
         super.init()
     }
@@ -53,7 +60,7 @@ public class WebSocketPublisher: NSObject {
             req.headerFields = headers
         }
         
-        let session = URLSession(configuration: .default, delegate: self, delegateQueue: OperationQueue())
+        let session = URLSession(configuration: .default, delegate: self, delegateQueue: _operationQueue)
         webSocketTask = session.webSocketTask(with: URLRequest(httpRequest: req)!)
         
         webSocketTask?.resume()
@@ -175,7 +182,7 @@ public class WebSocketPublisher: NSObject {
         guard let task = webSocketTask else { return }
         
         task.receiveOnce()
-            .receive(on: DispatchQueue.main)
+            .receive(on: _operationQueue)
             .sink { [weak self] result in
                 switch result {
                 case .finished:

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -59,7 +59,7 @@ public class WebSocketPublisher: NSObject {
     public func connect(with request: URLRequest, headers: HTTPFields? = nil) {
         var req = request.httpRequest!
         if let headers {
-            req.headerFields = headers
+            req.headerFields.append(contentsOf: headers)
         }
         
         let session = URLSession(configuration: .default, delegate: self, delegateQueue: _operationQueue)

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -27,12 +27,9 @@ public class WebSocketPublisher: NSObject {
     /// The [`Subject`](https://developer.apple.com/documentation/combine/subject) that publishes all received ``WebSocketPublisher/Event``s.
     internal let _subject = CurrentValueSubject<Event, Never>(.publisherCreated)
     
-    /// Returns the internal [Publisher](https://developer.apple.com/documentation/combine/publisher) (really a
-    /// [CurrentValueSubject](https://developer.apple.com/documentation/combine/currentvaluesubject)) as an
-    /// [AnyPublisher](https://developer.apple.com/documentation/combine/anypublisher).
-    /// 
-    /// Maintains clear and consistent terminology, and removes the possibility of developers sending
-    /// values to the subject.
+    /// A [`Publisher`](https://developer.apple.com/documentation/combine/publisher) that publishes all received ``WebSocketPublisher/Event``s.
+    ///
+    /// A type-erased [CurrentValueSubject](https://developer.apple.com/documentation/combine/currentvaluesubject), maintaining clear and consistent terminology, and removes the possibility of developers sending values to the subject.
     public var publisher: AnyPublisher<Event, Never> {
         _subject.eraseToAnyPublisher()
     }

--- a/Sources/WSPublisher/WebSocketPublisher.swift
+++ b/Sources/WSPublisher/WebSocketPublisher.swift
@@ -181,7 +181,7 @@ public class WebSocketPublisher: NSObject {
                 case .finished:
                     self?.startListening()
                 case .failure:
-                    self?.clearTaskData()
+                    break
                 }
             }, receiveValue: { [weak self] message in
                 switch message {

--- a/Tests/WSPublisherTests/XCTestManifests.swift
+++ b/Tests/WSPublisherTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(WSPublisher1Tests.allTests),
-    ]
-}
-#endif


### PR DESCRIPTION
Added misc updates:
- Added use of `HTTPTypes`
- Added `Hashable` conformance to `URLSessionWebSocketTask.Message`
- Added new struct detailing HTTP headers received from server when upgrading connection (type is `Sendable`/`Hashable`)
- Added new struct to organize details of a `disconnected` event
- Abbreviated names of some nested types
- Updated/fixed documentation
- Added support for including custom HTTP headers when initiating a connection
- Implemented internal custom `OperationQueue` instead of running everything on main thread